### PR TITLE
fixed removed port replacement

### DIFF
--- a/monitoring-stack/values.yaml
+++ b/monitoring-stack/values.yaml
@@ -108,6 +108,7 @@ prometheus:
         action: keep
         regex: 'k8s-ephemeral-storage-metrics'
       - source_labels: [__meta_kubernetes_pod_ip]
+        replacement: '${1}:9100'
         target_label: __address__
     - job_name: 'snmp-pdus'
       static_configs:


### PR DESCRIPTION
The bug occurred because Prometheus was trying to connect via 80 port instead of 9100.
It happens because one line was deleted occasionally by a Piao.
https://github.com/glaciation-heu/monitoring-stack/commit/0c91185a32808fe0b908b49005f0a9d5f866a68c